### PR TITLE
Publish fixture-versioned@v0.0.6

### DIFF
--- a/modules/fixture-versioned/0.0.6/MODULE.bazel
+++ b/modules/fixture-versioned/0.0.6/MODULE.bazel
@@ -1,0 +1,4 @@
+module(
+    name = "fixture-versioned",
+    version = "0.0.6",
+)

--- a/modules/fixture-versioned/0.0.6/presubmit.yml
+++ b/modules/fixture-versioned/0.0.6/presubmit.yml
@@ -1,0 +1,12 @@
+bcr_test_module:
+  module_path: "."
+  matrix:
+    platform: ["debian10", "macos", "ubuntu2004", "windows"]
+    bazel: [7.x]
+  tasks:
+    run_tests:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - "//..."

--- a/modules/fixture-versioned/0.0.6/source.json
+++ b/modules/fixture-versioned/0.0.6/source.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "sha256-cOA5viYJyem1ujP0auy3poTeG7hch1BIsL0bNzWlnZQ=",
+    "strip_prefix": "fixture-versioned-0.0.6",
+    "url": "https://github.com/publish-to-bcr-dev/fixture-versioned/releases/download/v0.0.6/fixture-versioned-v0.0.6.tar.gz"
+}

--- a/modules/fixture-versioned/metadata.json
+++ b/modules/fixture-versioned/metadata.json
@@ -1,0 +1,17 @@
+{
+    "homepage": "https://github.com/publish-to-bcr-dev/fixture-versioned",
+    "maintainers": [
+        {
+            "name": "Derek Cormier",
+            "email": "derek@aspect.build",
+            "github": "kormide"
+        }
+    ],
+    "repository": [
+        "github:publish-to-bcr-dev/fixture-versioned"
+    ],
+    "versions": [
+        "0.0.6"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/publish-to-bcr-dev/bazel-lib/releases/tag/v0.0.6

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_