### PR TITLE
Publish fixture-unversioned@v0.0.2

### DIFF
--- a/modules/fixture-unversioned/0.0.2/MODULE.bazel
+++ b/modules/fixture-unversioned/0.0.2/MODULE.bazel
@@ -1,0 +1,4 @@
+module(
+    name = "fixture-unversioned",
+    version = "0.0.2",
+)

--- a/modules/fixture-unversioned/0.0.2/patches/module_dot_bazel_version.patch
+++ b/modules/fixture-unversioned/0.0.2/patches/module_dot_bazel_version.patch
@@ -1,0 +1,9 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,4 +1,4 @@
+ module(
+     name = "fixture-unversioned",
+-    version = "0.0.0",
++    version = "0.0.2",
+ )

--- a/modules/fixture-unversioned/0.0.2/presubmit.yml
+++ b/modules/fixture-unversioned/0.0.2/presubmit.yml
@@ -1,0 +1,12 @@
+bcr_test_module:
+  module_path: "."
+  matrix:
+    platform: ["debian10", "macos", "ubuntu2004", "windows"]
+    bazel: [7.x]
+  tasks:
+    run_tests:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - "//..."

--- a/modules/fixture-unversioned/0.0.2/source.json
+++ b/modules/fixture-unversioned/0.0.2/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-U/C7UOBSZRC/nJXW++wGuID0/dfk5GVSvwXtbDD4ex8=",
+    "strip_prefix": "fixture-unversioned-0.0.2",
+    "url": "https://github.com/publish-to-bcr-dev/fixture-unversioned/releases/download/v0.0.2/fixture-unversioned-v0.0.2.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-keDUPjru2hkqtl8GRYSQp2I/Nbsq6JLU7pkiGvWzEV0="
+    },
+    "patch_strip": 1
+}

--- a/modules/fixture-unversioned/metadata.json
+++ b/modules/fixture-unversioned/metadata.json
@@ -1,0 +1,17 @@
+{
+    "homepage": "https://github.com/publish-to-bcr-dev/fixture-unversioned",
+    "maintainers": [
+        {
+            "name": "Derek Cormier",
+            "email": "derek@aspect.build",
+            "github": "kormide"
+        }
+    ],
+    "repository": [
+        "github:publish-to-bcr-dev/fixture-unversioned"
+    ],
+    "versions": [
+        "0.0.2"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/publish-to-bcr-dev/bazel-lib/releases/tag/v0.0.2

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_