### PR TITLE
Publish fixture-unversioned@v0.0.3

### DIFF
--- a/modules/fixture-unversioned/0.0.3/MODULE.bazel
+++ b/modules/fixture-unversioned/0.0.3/MODULE.bazel
@@ -1,0 +1,4 @@
+module(
+    name = "fixture-unversioned",
+    version = "0.0.3",
+)

--- a/modules/fixture-unversioned/0.0.3/attestations.json
+++ b/modules/fixture-unversioned/0.0.3/attestations.json
@@ -1,0 +1,19 @@
+{
+    "types": [
+        "https://slsa.dev/provenance/v1"
+    ],
+    "attestations": {
+        "source.json.intoto.jsonl": {
+            "url": "https://github.com/publish-to-bcr-dev/fixture-unversioned/releases/download/v0.0.3/source.json.intoto.jsonl",
+            "integrity": "sha256-49QQCnrVhvPEIc4I4C+2q+d/IcdEOak6qNmsy0kRxF8="
+        },
+        "MODULE.bazel.intoto.jsonl": {
+            "url": "https://github.com/publish-to-bcr-dev/fixture-unversioned/releases/download/v0.0.3/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-d1zWqWj1GsyYtczPNAzDV+S+/0KcZqXSyc+x9SHdbyE="
+        },
+        "fixture-unversioned-v0.0.3.tar.gz.intoto.jsonl": {
+            "url": "https://github.com/publish-to-bcr-dev/fixture-unversioned/releases/download/v0.0.3/fixture-unversioned-v0.0.3.tar.gz.intoto.jsonl",
+            "integrity": "sha256-5tr08hM9eN4gO9ptz9QW/1AQIEbDuuPx/ISp906THKQ="
+        }
+    }
+}

--- a/modules/fixture-unversioned/0.0.3/patches/module_dot_bazel_version.patch
+++ b/modules/fixture-unversioned/0.0.3/patches/module_dot_bazel_version.patch
@@ -1,0 +1,9 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,4 +1,4 @@
+ module(
+     name = "fixture-unversioned",
+-    version = "0.0.0",
++    version = "0.0.3",
+ )

--- a/modules/fixture-unversioned/0.0.3/presubmit.yml
+++ b/modules/fixture-unversioned/0.0.3/presubmit.yml
@@ -1,0 +1,12 @@
+bcr_test_module:
+  module_path: "."
+  matrix:
+    platform: ["debian10", "macos", "ubuntu2004", "windows"]
+    bazel: [7.x]
+  tasks:
+    run_tests:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - "//..."

--- a/modules/fixture-unversioned/0.0.3/source.json
+++ b/modules/fixture-unversioned/0.0.3/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-OW7NICBE9Qb0L3sPGoqG95HePgA/Utg2r/AzSYt4W/U=",
+    "strip_prefix": "fixture-unversioned-0.0.3",
+    "url": "https://github.com/publish-to-bcr-dev/fixture-unversioned/releases/download/v0.0.3/fixture-unversioned-v0.0.3.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-Uvg+FxnSKB7bD5aCkS2SqmSghgF4h7S0rI9czZDC5i8="
+    },
+    "patch_strip": 1
+}

--- a/modules/fixture-unversioned/metadata.json
+++ b/modules/fixture-unversioned/metadata.json
@@ -1,0 +1,17 @@
+{
+    "homepage": "https://github.com/publish-to-bcr-dev/fixture-unversioned",
+    "maintainers": [
+        {
+            "name": "Derek Cormier",
+            "email": "derek@aspect.build",
+            "github": "kormide"
+        }
+    ],
+    "repository": [
+        "github:publish-to-bcr-dev/fixture-unversioned"
+    ],
+    "versions": [
+        "0.0.3"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/publish-to-bcr-dev/bazel-lib/releases/tag/v0.0.3

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_