### PR TITLE
Publish fixture-unversioned@v0.0.4

### DIFF
--- a/modules/fixture-unversioned/0.0.4/MODULE.bazel
+++ b/modules/fixture-unversioned/0.0.4/MODULE.bazel
@@ -1,0 +1,4 @@
+module(
+    name = "fixture-unversioned",
+    version = "0.0.4",
+)

--- a/modules/fixture-unversioned/0.0.4/attestations.json
+++ b/modules/fixture-unversioned/0.0.4/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/publish-to-bcr-dev/fixture-unversioned/releases/download/v0.0.4/source.json.intoto.jsonl",
+            "integrity": "sha256-Afj9QHWdNHLJ9wRk4B/9UvCtF48x6mfkBBnkkpezMMg="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/publish-to-bcr-dev/fixture-unversioned/releases/download/v0.0.4/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-VyMImkiz9/9SGQCjYVw9gZt2cbuusF6qaMHciNeFfYw="
+        },
+        "fixture-unversioned-v0.0.4.tar.gz": {
+            "url": "https://github.com/publish-to-bcr-dev/fixture-unversioned/releases/download/v0.0.4/fixture-unversioned-v0.0.4.tar.gz.intoto.jsonl",
+            "integrity": "sha256-GygwEdfc01YtCCFKkfcr98W8mKn9FrT7leIsS2XPoI4="
+        }
+    }
+}

--- a/modules/fixture-unversioned/0.0.4/patches/module_dot_bazel_version.patch
+++ b/modules/fixture-unversioned/0.0.4/patches/module_dot_bazel_version.patch
@@ -1,0 +1,9 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,4 +1,4 @@
+ module(
+     name = "fixture-unversioned",
+-    version = "0.0.0",
++    version = "0.0.4",
+ )

--- a/modules/fixture-unversioned/0.0.4/presubmit.yml
+++ b/modules/fixture-unversioned/0.0.4/presubmit.yml
@@ -1,0 +1,12 @@
+bcr_test_module:
+  module_path: "."
+  matrix:
+    platform: ["debian10", "macos", "ubuntu2004", "windows"]
+    bazel: [7.x]
+  tasks:
+    run_tests:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - "//..."

--- a/modules/fixture-unversioned/0.0.4/source.json
+++ b/modules/fixture-unversioned/0.0.4/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-jX2GJ4s1zDgMM5tRBZtjwQ2PKi42oWhpLvyvnOH+Hik=",
+    "strip_prefix": "fixture-unversioned-0.0.4",
+    "url": "https://github.com/publish-to-bcr-dev/fixture-unversioned/releases/download/v0.0.4/fixture-unversioned-v0.0.4.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-Pp0uQQLGCZCG81BZch0DzQUiVszz61jCOnTAiZiUlz8="
+    },
+    "patch_strip": 1
+}

--- a/modules/fixture-unversioned/metadata.json
+++ b/modules/fixture-unversioned/metadata.json
@@ -1,0 +1,17 @@
+{
+    "homepage": "https://github.com/publish-to-bcr-dev/fixture-unversioned",
+    "maintainers": [
+        {
+            "name": "Derek Cormier",
+            "email": "derek@aspect.build",
+            "github": "kormide"
+        }
+    ],
+    "repository": [
+        "github:publish-to-bcr-dev/fixture-unversioned"
+    ],
+    "versions": [
+        "0.0.4"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/publish-to-bcr-dev/fixture-unversioned/releases/tag/v0.0.4

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_