### PR TITLE
Publish fixture-unversioned@0.0.5

### DIFF
--- a/modules/fixture-unversioned/0.0.5/MODULE.bazel
+++ b/modules/fixture-unversioned/0.0.5/MODULE.bazel
@@ -1,0 +1,4 @@
+module(
+    name = "fixture-unversioned",
+    version = "0.0.5",
+)

--- a/modules/fixture-unversioned/0.0.5/attestations.json
+++ b/modules/fixture-unversioned/0.0.5/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/publish-to-bcr-dev/fixture-unversioned/releases/download/v0.0.5/source.json.intoto.jsonl",
+            "integrity": "sha256-u4JaOa82Ug4ZNvbc0Jbu6Wp+U26p6+oS3lZeZEHuWug="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/publish-to-bcr-dev/fixture-unversioned/releases/download/v0.0.5/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-orJUvRKiXDQ3QlEIZkTY192CTDYFIivTx61T4iTbRzU="
+        },
+        "fixture-unversioned-v0.0.5.tar.gz": {
+            "url": "https://github.com/publish-to-bcr-dev/fixture-unversioned/releases/download/v0.0.5/fixture-unversioned-v0.0.5.tar.gz.intoto.jsonl",
+            "integrity": "sha256-a/E63FJOZvTnZN2tYWjQv1wkDzxGfJkA5RJj8sSQ3GA="
+        }
+    }
+}

--- a/modules/fixture-unversioned/0.0.5/patches/module_dot_bazel_version.patch
+++ b/modules/fixture-unversioned/0.0.5/patches/module_dot_bazel_version.patch
@@ -1,0 +1,9 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,4 +1,4 @@
+ module(
+     name = "fixture-unversioned",
+-    version = "0.0.0",
++    version = "0.0.5",
+ )

--- a/modules/fixture-unversioned/0.0.5/presubmit.yml
+++ b/modules/fixture-unversioned/0.0.5/presubmit.yml
@@ -1,0 +1,12 @@
+bcr_test_module:
+  module_path: "."
+  matrix:
+    platform: ["debian10", "macos", "ubuntu2004", "windows"]
+    bazel: [7.x]
+  tasks:
+    run_tests:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - "//..."

--- a/modules/fixture-unversioned/0.0.5/source.json
+++ b/modules/fixture-unversioned/0.0.5/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-r6/icdKWiQHTsCz6RSjSCYJzJb9NB17MI0vCvkJy6eY=",
+    "strip_prefix": "fixture-unversioned-0.0.5",
+    "url": "https://github.com/publish-to-bcr-dev/fixture-unversioned/releases/download/v0.0.5/fixture-unversioned-v0.0.5.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-ZNOYzEhfTOA7ycFnDtCJjupgQTw0QGAPVYEDolJkIWI="
+    },
+    "patch_strip": 1
+}

--- a/modules/fixture-unversioned/metadata.json
+++ b/modules/fixture-unversioned/metadata.json
@@ -1,0 +1,17 @@
+{
+    "homepage": "https://github.com/publish-to-bcr-dev/fixture-unversioned",
+    "maintainers": [
+        {
+            "name": "Derek Cormier",
+            "email": "derek@aspect.build",
+            "github": "kormide"
+        }
+    ],
+    "repository": [
+        "github:publish-to-bcr-dev/fixture-unversioned"
+    ],
+    "versions": [
+        "0.0.5"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/publish-to-bcr-dev/fixture-unversioned/releases/tag/v0.0.5

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_