### PR TITLE
Publish fixture-unversioned@0.0.10

### DIFF
--- a/modules/fixture-unversioned/0.0.10/MODULE.bazel
+++ b/modules/fixture-unversioned/0.0.10/MODULE.bazel
@@ -1,0 +1,4 @@
+module(
+    name = "fixture-unversioned",
+    version = "0.0.10",
+)

--- a/modules/fixture-unversioned/0.0.10/attestations.json
+++ b/modules/fixture-unversioned/0.0.10/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/publish-to-bcr-dev/fixture-unversioned/releases/download/v0.0.10/source.json.intoto.jsonl",
+            "integrity": "sha256-u4Hfop+sY3j0SX1Wd5qZd7kH82XYIyYTsa6CYpRNYNA="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/publish-to-bcr-dev/fixture-unversioned/releases/download/v0.0.10/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-9bT9Oupdt1HPpdksnQKuB0UkyNe8yPCmeqjqCEyDusI="
+        },
+        "fixture-unversioned-v0.0.10.tar.gz": {
+            "url": "https://github.com/publish-to-bcr-dev/fixture-unversioned/releases/download/v0.0.10/fixture-unversioned-v0.0.10.tar.gz.intoto.jsonl",
+            "integrity": "sha256-1RF/MeIlRJojevLQJd0hhei6NL54H7rReTggcbV/t3A="
+        }
+    }
+}

--- a/modules/fixture-unversioned/0.0.10/patches/module_dot_bazel_version.patch
+++ b/modules/fixture-unversioned/0.0.10/patches/module_dot_bazel_version.patch
@@ -1,0 +1,9 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,4 +1,4 @@
+ module(
+     name = "fixture-unversioned",
+-    version = "0.0.0",
++    version = "0.0.10",
+ )

--- a/modules/fixture-unversioned/0.0.10/presubmit.yml
+++ b/modules/fixture-unversioned/0.0.10/presubmit.yml
@@ -1,0 +1,12 @@
+bcr_test_module:
+  module_path: "."
+  matrix:
+    platform: ["debian10", "macos", "ubuntu2004", "windows"]
+    bazel: [7.x]
+  tasks:
+    run_tests:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - "//..."

--- a/modules/fixture-unversioned/0.0.10/source.json
+++ b/modules/fixture-unversioned/0.0.10/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-QJlhDtt9bzq60kR7L6nRsLTPzIwOLIzZBserfMMdkGI=",
+    "strip_prefix": "fixture-unversioned-0.0.10",
+    "url": "https://github.com/publish-to-bcr-dev/fixture-unversioned/releases/download/v0.0.10/fixture-unversioned-v0.0.10.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-DAE1+CyMHggGTKZnyuYDfIaQUyljvIbCdMZkkdRcV90="
+    },
+    "patch_strip": 1
+}

--- a/modules/fixture-unversioned/metadata.json
+++ b/modules/fixture-unversioned/metadata.json
@@ -1,0 +1,17 @@
+{
+    "homepage": "https://github.com/publish-to-bcr-dev/fixture-unversioned",
+    "maintainers": [
+        {
+            "name": "Derek Cormier",
+            "email": "derek@aspect.build",
+            "github": "kormide"
+        }
+    ],
+    "repository": [
+        "github:publish-to-bcr-dev/fixture-unversioned"
+    ],
+    "versions": [
+        "0.0.10"
+    ],
+    "yanked_versions": {}
+}

--- a/tools/attestations.py
+++ b/tools/attestations.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import dataclasses
+import re
 
 
 class Error(Exception):
@@ -59,10 +60,13 @@ def parse_file(attestations_json, module_name, version, registry):
         # already ensures that source_url points to the correct repository.
         # Consequently, we only need to check that all URLs start
         # with url_prefix.
-        expected_url = f"{url_prefix}/{basename}.intoto.jsonl"
         url = metadata["url"]
-        if url != expected_url:
-            raise Error(f"Expected url {expected_url}, but got {url} in {basename} attestation.")
+        # Basename can have an optional prefix since a GitHub release may
+        # contain multiple modules (and thus attestation files).
+        if not re.match(f"^{url_prefix}/[^/]*{basename}.intoto.jsonl$", url):
+            raise Error(
+                f"Expected url {url_prefix}/[prefix]{basename}.intoto.jsonl, but got {url} in {basename} attestation."
+            )
 
         integrity = metadata["integrity"]
         if not integrity:


### PR DESCRIPTION
Release: https://github.com/publish-to-bcr-dev/fixture-unversioned/releases/tag/v0.0.10

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_