### PR TITLE
Publish fixture-versioned@0.0.9

### DIFF
--- a/modules/fixture-versioned/0.0.9/MODULE.bazel
+++ b/modules/fixture-versioned/0.0.9/MODULE.bazel
@@ -1,0 +1,4 @@
+module(
+    name = "fixture-versioned",
+    version = "0.0.9",
+)

--- a/modules/fixture-versioned/0.0.9/attestations.json
+++ b/modules/fixture-versioned/0.0.9/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/publish-to-bcr-dev/fixture-versioned/releases/download/v0.0.9/source.json.intoto.jsonl",
+            "integrity": "sha256-V3DKGkg7vPhX/YbDgVCc6br6+4xgkZ2dXIHdHfXYF4g="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/publish-to-bcr-dev/fixture-versioned/releases/download/v0.0.9/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-86oBlIB2mctaUYrrpfXYqhDszX+eT4JITZe5t5jtIng="
+        },
+        "fixture-versioned-v0.0.9.tar.gz": {
+            "url": "https://github.com/publish-to-bcr-dev/fixture-versioned/releases/download/v0.0.9/fixture-versioned-v0.0.9.tar.gz.intoto.jsonl",
+            "integrity": "sha256-0YSrl19+1VqiBl8Ev/eVNMBzE8LIfhU5JAZnqHrWemY="
+        }
+    }
+}

--- a/modules/fixture-versioned/0.0.9/presubmit.yml
+++ b/modules/fixture-versioned/0.0.9/presubmit.yml
@@ -1,0 +1,12 @@
+bcr_test_module:
+  module_path: "."
+  matrix:
+    platform: ["debian10", "macos", "ubuntu2004", "windows"]
+    bazel: [7.x]
+  tasks:
+    run_tests:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - "//..."

--- a/modules/fixture-versioned/0.0.9/source.json
+++ b/modules/fixture-versioned/0.0.9/source.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "sha256-zRlUFbqOgc15pcMc3UuWG5Q2ThR0sr9xLYHnjJLafe0=",
+    "strip_prefix": "fixture-versioned-0.0.9",
+    "url": "https://github.com/publish-to-bcr-dev/fixture-versioned/releases/download/v0.0.9/fixture-versioned-v0.0.9.tar.gz"
+}

--- a/modules/fixture-versioned/metadata.json
+++ b/modules/fixture-versioned/metadata.json
@@ -1,0 +1,17 @@
+{
+    "homepage": "https://github.com/publish-to-bcr-dev/fixture-versioned",
+    "maintainers": [
+        {
+            "name": "Derek Cormier",
+            "email": "derek@aspect.build",
+            "github": "kormide"
+        }
+    ],
+    "repository": [
+        "github:publish-to-bcr-dev/fixture-versioned"
+    ],
+    "versions": [
+        "0.0.9"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/publish-to-bcr-dev/fixture-versioned/releases/tag/v0.0.9

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_