### PR TITLE
Publish fixture-versioned@0.0.16

### DIFF
--- a/modules/fixture-versioned/0.0.16/MODULE.bazel
+++ b/modules/fixture-versioned/0.0.16/MODULE.bazel
@@ -1,0 +1,4 @@
+module(
+    name = "fixture-versioned",
+    version = "0.0.16",
+)

--- a/modules/fixture-versioned/0.0.16/attestations.json
+++ b/modules/fixture-versioned/0.0.16/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/publish-to-bcr-dev/fixture-versioned/releases/download/v0.0.16/source.json.intoto.jsonl",
+            "integrity": "sha256-YWUkL9OWq+0oLthtDFL3fH1SlpYtKZOi7dkkjSwHTMM="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/publish-to-bcr-dev/fixture-versioned/releases/download/v0.0.16/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-bBrX732L6tL8apbGXP8pB0GkpfmAEmedBJ7cGMX+StI="
+        },
+        "fixture-versioned-v0.0.16.tar.gz": {
+            "url": "https://github.com/publish-to-bcr-dev/fixture-versioned/releases/download/v0.0.16/fixture-versioned-v0.0.16.tar.gz.intoto.jsonl",
+            "integrity": "sha256-Sw2j246hOqTNdVNXe53+PyvmJ0RkHF1KXbk82uM7h7Y="
+        }
+    }
+}

--- a/modules/fixture-versioned/0.0.16/presubmit.yml
+++ b/modules/fixture-versioned/0.0.16/presubmit.yml
@@ -1,0 +1,12 @@
+bcr_test_module:
+  module_path: "."
+  matrix:
+    platform: ["debian10", "macos", "ubuntu2004", "windows"]
+    bazel: [7.x]
+  tasks:
+    run_tests:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - "//..."

--- a/modules/fixture-versioned/0.0.16/source.json
+++ b/modules/fixture-versioned/0.0.16/source.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "sha256-bHSkm5cpLLPMbPikDG2xOjuRm6gQBb4xCWmknp/tdjY=",
+    "strip_prefix": "fixture-versioned-0.0.16",
+    "url": "https://github.com/publish-to-bcr-dev/fixture-versioned/releases/download/v0.0.16/fixture-versioned-v0.0.16.tar.gz"
+}

--- a/modules/fixture-versioned/metadata.json
+++ b/modules/fixture-versioned/metadata.json
@@ -1,0 +1,17 @@
+{
+    "homepage": "https://github.com/publish-to-bcr-dev/fixture-versioned",
+    "maintainers": [
+        {
+            "name": "Derek Cormier",
+            "email": "derek@aspect.build",
+            "github": "kormide"
+        }
+    ],
+    "repository": [
+        "github:publish-to-bcr-dev/fixture-versioned"
+    ],
+    "versions": [
+        "0.0.16"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/publish-to-bcr-dev/fixture-versioned/releases/tag/v0.0.16

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_