### PR TITLE
Publish fixture-versioned@0.0.22

### DIFF
--- a/modules/fixture-versioned/0.0.22/MODULE.bazel
+++ b/modules/fixture-versioned/0.0.22/MODULE.bazel
@@ -1,0 +1,4 @@
+module(
+    name = "fixture-versioned",
+    version = "0.0.22",
+)

--- a/modules/fixture-versioned/0.0.22/attestations.json
+++ b/modules/fixture-versioned/0.0.22/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/publish-to-bcr-dev/fixture-versioned/releases/download/v0.0.22/source.json.intoto.jsonl",
+            "integrity": "sha256-I+cltxXyINH+meJ3qd4arwCj+cvskrzZF42c+5icNLw="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/publish-to-bcr-dev/fixture-versioned/releases/download/v0.0.22/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-33eC4o5+Rucy/5NYWr9WY6locfuBcLn1N7SxzXw4FfU="
+        },
+        "fixture-versioned-v0.0.22.tar.gz": {
+            "url": "https://github.com/publish-to-bcr-dev/fixture-versioned/releases/download/v0.0.22/fixture-versioned-v0.0.22.tar.gz.intoto.jsonl",
+            "integrity": "sha256-Fdro2H++qij+OwEjoJlqyH8yk7tBOp5UaUJnldGBfjw="
+        }
+    }
+}

--- a/modules/fixture-versioned/0.0.22/presubmit.yml
+++ b/modules/fixture-versioned/0.0.22/presubmit.yml
@@ -1,0 +1,12 @@
+bcr_test_module:
+  module_path: "."
+  matrix:
+    platform: ["debian10", "macos", "ubuntu2004", "windows"]
+    bazel: [7.x]
+  tasks:
+    run_tests:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - "//..."

--- a/modules/fixture-versioned/0.0.22/source.json
+++ b/modules/fixture-versioned/0.0.22/source.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "sha256-4AGTbLMCQDpCOwP1qBLab2zAtQatVArWLBNu1DEY04E=",
+    "strip_prefix": "fixture-versioned-0.0.22",
+    "url": "https://github.com/publish-to-bcr-dev/fixture-versioned/releases/download/v0.0.22/fixture-versioned-v0.0.22.tar.gz"
+}

--- a/modules/fixture-versioned/metadata.json
+++ b/modules/fixture-versioned/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/publish-to-bcr-dev/fixture-versioned",
+    "maintainers": [
+        {
+            "name": "Derek Cormier",
+            "email": "derek@aspect.build",
+            "github": "kormide",
+            "github_user_id": 4948761
+        }
+    ],
+    "repository": [
+        "github:publish-to-bcr-dev/fixture-versioned"
+    ],
+    "versions": [
+        "0.0.22"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/publish-to-bcr-dev/fixture-versioned/releases/tag/v0.0.22

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_