### PR TITLE
Publish fixture-versioned@0.0.25

### DIFF
--- a/modules/fixture-versioned/0.0.25/MODULE.bazel
+++ b/modules/fixture-versioned/0.0.25/MODULE.bazel
@@ -1,0 +1,4 @@
+module(
+    name = "fixture-versioned",
+    version = "0.0.25",
+)

--- a/modules/fixture-versioned/0.0.25/attestations.json
+++ b/modules/fixture-versioned/0.0.25/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/publish-to-bcr-dev/fixture-versioned/releases/download/v0.0.25/source.json.intoto.jsonl",
+            "integrity": "sha256-b3JnAKQc/llPnx1/n+QDd6nKGa+qdXxkWMyGx6BHytA="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/publish-to-bcr-dev/fixture-versioned/releases/download/v0.0.25/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-cRDpp2/6Ltbm5MJYsLjwrq75Ni8Y3Xcv4UP5KSHcbAE="
+        },
+        "fixture-versioned-v0.0.25.tar.gz": {
+            "url": "https://github.com/publish-to-bcr-dev/fixture-versioned/releases/download/v0.0.25/fixture-versioned-v0.0.25.tar.gz.intoto.jsonl",
+            "integrity": "sha256-KCGqytIsPoahkqnJ0+n1K6tv2eT7PQCHRIyAH0UmYzE="
+        }
+    }
+}

--- a/modules/fixture-versioned/0.0.25/presubmit.yml
+++ b/modules/fixture-versioned/0.0.25/presubmit.yml
@@ -1,0 +1,12 @@
+bcr_test_module:
+  module_path: "."
+  matrix:
+    platform: ["debian10", "macos", "ubuntu2004", "windows"]
+    bazel: [7.x]
+  tasks:
+    run_tests:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - "//..."

--- a/modules/fixture-versioned/0.0.25/source.json
+++ b/modules/fixture-versioned/0.0.25/source.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "sha256-e3Xm4qUEJhpLuCEVs9HqU779+0wl6nHXvRnYZjTwb7E=",
+    "strip_prefix": "fixture-versioned-0.0.25",
+    "url": "https://github.com/publish-to-bcr-dev/fixture-versioned/releases/download/v0.0.25/fixture-versioned-v0.0.25.tar.gz"
+}

--- a/modules/fixture-versioned/metadata.json
+++ b/modules/fixture-versioned/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/publish-to-bcr-dev/fixture-versioned",
+    "maintainers": [
+        {
+            "name": "Derek Cormier",
+            "email": "derek@aspect.build",
+            "github": "kormide",
+            "github_user_id": 4948761
+        }
+    ],
+    "repository": [
+        "github:publish-to-bcr-dev/fixture-versioned"
+    ],
+    "versions": [
+        "0.0.25"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/publish-to-bcr-dev/fixture-versioned/releases/tag/v0.0.25

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_